### PR TITLE
db: support arbitrary passwords

### DIFF
--- a/cogs/utils/db/misc.py
+++ b/cogs/utils/db/misc.py
@@ -14,7 +14,7 @@ async def _set_codec(conn):
     )
 
 
-async def create_pool(dsn, *, init=None, **kwargs):
+async def create_pool(*, init=None, **kwargs):
     if init is None:
         async def new_init(conn):
             await _set_codec(conn)
@@ -23,4 +23,4 @@ async def create_pool(dsn, *, init=None, **kwargs):
             await _set_codec(conn)
             await init(conn)
 
-    return await asyncpg.create_pool(dsn, init=new_init, **kwargs)
+    return await asyncpg.create_pool(init=new_init, **kwargs)

--- a/core/bot.py
+++ b/core/bot.py
@@ -152,8 +152,13 @@ class Chiaki(commands.AutoShardedBot):
 
         self.reset_requested = False
 
-        psql = f'postgresql://{config.psql_user}:{config.psql_pass}@{config.psql_host}/{config.psql_db}'
-        self.pool = self.loop.run_until_complete(db.create_pool(psql, command_timeout=60))
+        psql = dict(
+            user=config.psql_user,
+            password=config.psql_pass,
+            host=config.psql_host,
+            database=config.psql_db
+        )
+        self.pool = self.loop.run_until_complete(db.create_pool(**psql, command_timeout=60))
 
         self.db_scheduler = DatabaseScheduler(self.pool, timefunc=datetime.utcnow)
         self.db_scheduler.add_callback(self._dispatch_from_scheduler)


### PR DESCRIPTION
old system of manually generating a DSN did not support / in passwords.
I always make user accounts with randomly generated passwords, and i would rather
not exclude / from them.